### PR TITLE
Copy all attributes from inner function

### DIFF
--- a/crates/risc0-cycle-macros/src/lib.rs
+++ b/crates/risc0-cycle-macros/src/lib.rs
@@ -29,6 +29,7 @@ fn wrap_function(input: ItemFn) -> Result<TokenStream, syn::Error> {
     let visibility = &input.vis;
     let name = &input.sig.ident;
     let inputs = &input.sig.inputs;
+    let _docs: Vec<&syn::Attribute> = input.attrs.iter().filter(|&attr| attr.path().is_ident("doc")).collect();
     let output = &input.sig.output;
     let block = &input.block;
     let generics = &input.sig.generics;
@@ -37,7 +38,9 @@ fn wrap_function(input: ItemFn) -> Result<TokenStream, syn::Error> {
     let risc0_zkvm_platform =
         syn::Ident::new("risc0_zkvm_platform", proc_macro2::Span::call_site());
 
+    //         #( #docs )*
     let result = quote! {
+
         #visibility fn #name #generics (#inputs) #output #where_clause {
             let before = #risc0_zkvm_platform::syscall::sys_cycle_count();
             let result = (|| #block)();

--- a/crates/risc0-cycle-macros/src/lib.rs
+++ b/crates/risc0-cycle-macros/src/lib.rs
@@ -29,7 +29,7 @@ fn wrap_function(input: ItemFn) -> Result<TokenStream, syn::Error> {
     let visibility = &input.vis;
     let name = &input.sig.ident;
     let inputs = &input.sig.inputs;
-    let docs: Vec<&syn::Attribute> = input.attrs.iter().filter(|&attr| attr.path().is_ident("doc")).collect();
+    let attributes= &input.attrs;
     let output = &input.sig.output;
     let block = &input.block;
     let generics = &input.sig.generics;
@@ -39,7 +39,7 @@ fn wrap_function(input: ItemFn) -> Result<TokenStream, syn::Error> {
         syn::Ident::new("risc0_zkvm_platform", proc_macro2::Span::call_site());
 
     let result = quote! {
-        #( #docs )*
+        #( #attributes )*
         #visibility fn #name #generics (#inputs) #output #where_clause {
             let before = #risc0_zkvm_platform::syscall::sys_cycle_count();
             let result = (|| #block)();

--- a/crates/risc0-cycle-macros/src/lib.rs
+++ b/crates/risc0-cycle-macros/src/lib.rs
@@ -29,7 +29,7 @@ fn wrap_function(input: ItemFn) -> Result<TokenStream, syn::Error> {
     let visibility = &input.vis;
     let name = &input.sig.ident;
     let inputs = &input.sig.inputs;
-    let _docs: Vec<&syn::Attribute> = input.attrs.iter().filter(|&attr| attr.path().is_ident("doc")).collect();
+    let docs: Vec<&syn::Attribute> = input.attrs.iter().filter(|&attr| attr.path().is_ident("doc")).collect();
     let output = &input.sig.output;
     let block = &input.block;
     let generics = &input.sig.generics;
@@ -38,9 +38,8 @@ fn wrap_function(input: ItemFn) -> Result<TokenStream, syn::Error> {
     let risc0_zkvm_platform =
         syn::Ident::new("risc0_zkvm_platform", proc_macro2::Span::call_site());
 
-    //         #( #docs )*
     let result = quote! {
-
+        #( #docs )*
         #visibility fn #name #generics (#inputs) #output #where_clause {
             let before = #risc0_zkvm_platform::syscall::sys_cycle_count();
             let result = (|| #block)();

--- a/crates/risc0-cycle-macros/tests/all_tests.rs
+++ b/crates/risc0-cycle-macros/tests/all_tests.rs
@@ -2,4 +2,5 @@
 fn cycle_macro_tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/cycle_macro.rs");
+    t.pass("tests/cycle_macro_with_docs.rs");
 }

--- a/crates/risc0-cycle-macros/tests/cycle_macro_with_docs.rs
+++ b/crates/risc0-cycle-macros/tests/cycle_macro_with_docs.rs
@@ -1,0 +1,11 @@
+#![deny(missing_docs)]
+//! Crate documentation
+
+use risc0_cycle_macros::cycle_tracker;
+
+/// Some documentation for function
+#[cycle_tracker]
+pub fn _function_without_params() {}
+
+/// Here goes the main
+pub fn main() {}


### PR DESCRIPTION
This should solve problem with missing docs:

```
  error: missing documentation for a function
     --> /home/runner/actions-runner/_work/sovereign-sdk-wip/sovereign-sdk-wip/module-system/sov-modules-stf-blueprint/src/stf_blueprint.rs:312:56
      |
  312 | #[cfg_attr(all(target_os = "zkvm", feature = "bench"), cycle_tracker)]
      |                                                        ^^^^^^^^^^^^^
      |
  note: the lint level is defined here
     --> /home/runner/actions-runner/_work/sovereign-sdk-wip/sovereign-sdk-wip/module-system/sov-modules-stf-blueprint/src/lib.rs:1:9
      |
  1   | #![deny(missing_docs)]
      |         ^^^^^^^^^^^^
      = note: this error originates in the attribute macro `cycle_tracker` (in Nightly builds, run with -Z macro-backtrace for more info)
      
```