### PR TITLE
Add sp1 support. Use facade to prevent feature explosion.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ risc0-zkvm = { version = "1.0.5", default-features = false }
 risc0-zkvm-platform = { version = "1.0", features = [
 	"export-syscalls",
 ], default-features = false }
+sp1-sdk = { version = "1", default-features = false }
+sp1-zkvm = { version = "1", default-features = false }

--- a/crates/sov-cycle-macros/Cargo.toml
+++ b/crates/sov-cycle-macros/Cargo.toml
@@ -27,5 +27,4 @@ proc-macro2 = "1"
 [dev-dependencies]
 trybuild = "1"
 sov-cycle-macros = { path = "" }
-risc0-zkvm = { workspace = true, default-features = false, features = ["std"] }
-risc0-zkvm-platform = { workspace = true }
+sov-cycle-utils = { path = "../utils" }

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -13,9 +13,15 @@ resolver = "2"
 autotests = false
 
 [dependencies]
-risc0-zkvm = { workspace = true, default-features = false, features = ["std"] }
-risc0-zkvm-platform = { workspace = true }
+sp1-sdk = { workspace = true, default-features = false, optional = true }
+sp1-zkvm = { workspace = true, default-features = false, optional = true }
+risc0-zkvm = { workspace = true, default-features = false, features = [
+	"std",
+], optional = true }
+risc0-zkvm-platform = { workspace = true, optional = true }
 
 [features]
-default = []
+default = ["risc0"]
+risc0 = ["dep:risc0-zkvm", "dep:risc0-zkvm-platform"]
+sp1 = ["dep:sp1-sdk", "dep:sp1-zkvm"]
 native = ["risc0-zkvm/prove"]

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -19,9 +19,11 @@ risc0-zkvm = { workspace = true, default-features = false, features = [
 	"std",
 ], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
+sov-cycle-macros = { path = "../sov-cycle-macros", optional = true }
 
 [features]
-default = ["risc0"]
+default = ["macros"]
+macros = ["dep:sov-cycle-macros"]
 risc0 = ["dep:risc0-zkvm", "dep:risc0-zkvm-platform"]
 sp1 = ["dep:sp1-sdk", "dep:sp1-zkvm"]
 native = ["risc0-zkvm/prove"]

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "risc0")]
+#[cfg(feature = "macros")]
+pub use sov_cycle_macros as macros;
 pub mod risc0;
-#[cfg(feature = "sp1")]
 pub mod sp1;

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -1,9 +1,4 @@
-use risc0_zkvm_platform::syscall::SyscallName;
-
-// Safety: string is null terminated
-pub const SYSCALL_NAME_METRICS: SyscallName =
-    unsafe { SyscallName::from_bytes_with_nul("cycle_metrics\0".as_bytes().as_ptr()) };
-
-pub fn get_syscall_name() -> SyscallName {
-    SYSCALL_NAME_METRICS
-}
+#[cfg(feature = "risc0")]
+pub mod risc0;
+#[cfg(feature = "sp1")]
+pub mod sp1;

--- a/crates/utils/src/risc0.rs
+++ b/crates/utils/src/risc0.rs
@@ -1,0 +1,11 @@
+pub use risc0_zkvm;
+pub use risc0_zkvm_platform::syscall::sys_cycle_count;
+pub use risc0_zkvm_platform::syscall::SyscallName;
+
+// Safety: string is null terminated
+pub const SYSCALL_NAME_METRICS: SyscallName =
+    unsafe { SyscallName::from_bytes_with_nul("cycle_metrics\0".as_bytes().as_ptr()) };
+
+pub fn get_syscall_name() -> SyscallName {
+    SYSCALL_NAME_METRICS
+}

--- a/crates/utils/src/risc0.rs
+++ b/crates/utils/src/risc0.rs
@@ -1,11 +1,46 @@
-pub use risc0_zkvm;
-pub use risc0_zkvm_platform::syscall::sys_cycle_count;
-pub use risc0_zkvm_platform::syscall::SyscallName;
+#[cfg(feature = "risc0")]
+pub use actual_impl::*;
 
-// Safety: string is null terminated
-pub const SYSCALL_NAME_METRICS: SyscallName =
-    unsafe { SyscallName::from_bytes_with_nul("cycle_metrics\0".as_bytes().as_ptr()) };
+#[cfg(feature = "risc0")]
+mod actual_impl {
+    use risc0_zkvm;
+    use risc0_zkvm_platform::syscall::sys_cycle_count;
+    use risc0_zkvm_platform::syscall::SyscallName;
 
-pub fn get_syscall_name() -> SyscallName {
-    SYSCALL_NAME_METRICS
+    // Safety: string is null terminated
+    pub const SYSCALL_NAME_METRICS: SyscallName =
+        unsafe { SyscallName::from_bytes_with_nul("cycle_metrics\0".as_bytes().as_ptr()) };
+
+    pub fn get_syscall_name() -> SyscallName {
+        SYSCALL_NAME_METRICS
+    }
+
+    pub fn get_cycle_count() -> u64 {
+        sys_cycle_count()
+    }
+
+    pub fn report_cycle_count(name: &str, count: u64) {
+        // simple serialization to avoid pulling in bincode or other libs
+        let mut serialized = Vec::new();
+        serialized.extend(name.as_bytes());
+        serialized.push(0);
+        let size_bytes = count.to_le_bytes();
+        serialized.extend(&size_bytes);
+
+        // calculate the syscall name.
+        let metrics_syscall_name = SYSCALL_NAME_METRICS;
+
+        risc0_zkvm::guest::env::send_recv_slice::<u8, u8>(metrics_syscall_name, &serialized);
+    }
+}
+
+#[cfg(not(feature = "risc0"))]
+pub use facade::*;
+#[cfg(not(feature = "risc0"))]
+mod facade {
+    pub fn get_cycle_count() -> u64 {
+        0
+    }
+
+    pub fn report_cycle_count(_name: &str, _count: u64) {}
 }

--- a/crates/utils/src/sp1.rs
+++ b/crates/utils/src/sp1.rs
@@ -1,0 +1,13 @@
+pub extern crate sp1_zkvm;
+/// File descriptor for the cycle count hook, which is used to get the cycle count.
+/// Can be any number, as long as it doesn't conflict with default/other hooks.
+pub const FD_CYCLE_COUNT_HOOK: u32 = 1000;
+/// File descriptor for the metrics hook, which is used to collect cycle duration data for functions.
+/// Can be any number, as long as it doesn't conflict with default/other hooks.
+pub const FD_METRICS_HOOK: u32 = 1001;
+
+pub fn cycle_count_hook(env: sp1_sdk::HookEnv, _buf: &[u8]) -> Vec<Vec<u8>> {
+    vec![Vec::from(
+        env.runtime.report.total_instruction_count().to_le_bytes(),
+    )]
+}

--- a/crates/utils/src/sp1.rs
+++ b/crates/utils/src/sp1.rs
@@ -1,13 +1,51 @@
-pub extern crate sp1_zkvm;
-/// File descriptor for the cycle count hook, which is used to get the cycle count.
-/// Can be any number, as long as it doesn't conflict with default/other hooks.
-pub const FD_CYCLE_COUNT_HOOK: u32 = 1000;
-/// File descriptor for the metrics hook, which is used to collect cycle duration data for functions.
-/// Can be any number, as long as it doesn't conflict with default/other hooks.
-pub const FD_METRICS_HOOK: u32 = 1001;
+#[cfg(feature = "sp1")]
+pub use actual_impl::*;
+#[cfg(feature = "sp1")]
+mod actual_impl {
+    use sp1_zkvm;
+    /// File descriptor for the cycle count hook, which is used to get the cycle count.
+    /// Can be any number, as long as it doesn't conflict with default/other hooks.
+    pub const FD_CYCLE_COUNT_HOOK: u32 = 1000;
+    /// File descriptor for the metrics hook, which is used to collect cycle duration data for functions.
+    /// Can be any number, as long as it doesn't conflict with default/other hooks.
+    pub const FD_METRICS_HOOK: u32 = 1001;
 
-pub fn cycle_count_hook(env: sp1_sdk::HookEnv, _buf: &[u8]) -> Vec<Vec<u8>> {
-    vec![Vec::from(
-        env.runtime.report.total_instruction_count().to_le_bytes(),
-    )]
+    pub fn cycle_count_hook(env: sp1_sdk::HookEnv, _buf: &[u8]) -> Vec<Vec<u8>> {
+        vec![Vec::from(
+            env.runtime.report.total_instruction_count().to_le_bytes(),
+        )]
+    }
+
+    /// Report the cycle count to the host, if available. Otherwise, this is a no-op.
+    pub fn report_cycle_count(name: &str, count: u64) {
+        // Cheap serialization: concat the u64 (fixed size) with the string (unknown size).
+        let mut buf = Vec::from(count.to_le_bytes());
+        buf.extend_from_slice(name.as_bytes());
+        sp1_zkvm::io::write(FD_METRICS_HOOK, &buf);
+    }
+
+    /// Get the current cycle count of the sp1 zkvm, if available. Otherwise, return 0.
+    pub fn get_cycle_count() -> u64 {
+        // Writing zero bytes is a no-op, so we write &[0].
+        sp1_zkvm::io::write(FD_CYCLE_COUNT_HOOK, &[0]);
+        u64::from_le_bytes(
+            sp1_zkvm::io::read_vec()
+                .try_into()
+                .expect("Failed to read cycle count before hook."),
+        )
+    }
+}
+
+#[cfg(not(feature = "sp1"))]
+pub use facade::*;
+
+#[cfg(not(feature = "sp1"))]
+mod facade {
+    /// Get the current cycle count of the sp1 zkvm, if available. Otherwise, return 0.
+    pub fn get_cycle_count() -> u64 {
+        0
+    }
+
+    /// Report the cycle count to the host, if available. Otherwise, this is a no-op.
+    pub fn report_cycle_count(_name: &str, _count: u64) {}
 }


### PR DESCRIPTION
This PR ports the [changes to add `sp1` support](https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/912) into this repo with some slight modifications. To consume this package, each zkvm adapter simply adds a `bench` dependency on `sov-cycle-utils` with the appropriate (vm-specific) feature flag enabled. 

You can see an example integration here: https://github.com/Sovereign-Labs/sovereign-sdk-wip/compare/preston/cycle-macros?expand=1