### PR TITLE
Add free heap calculation for risc0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,19 +3,17 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Sovereign Labs <info@sovereign.xyz>"]
 homepage = "https://www.sovereign.xyz"
 publish = true
-repository = "https://github.com/sovereign-labs/sov-cycle-macros"
+repository = "https://github.com/Sovereign-Labs/risc0-cycle-macros"
 
 [workspace.dependencies]
-risc0-zkvm = { version = "1.0.5", default-features = false }
-risc0-zkvm-platform = { version = "1.0", features = [
-	"export-syscalls",
-], default-features = false }
+risc0-zkvm = { version = "1.2", default-features = false }
+risc0-zkvm-platform = { version = "1.2", features = ["export-syscalls"], default-features = false }
 
-sp1-lib = { version = "1", default-features =  false }
-once_cell = { version = "1.19.0", default-features = false, features = ["std", "critical-section"]}
+sp1-lib = { version = "3.0", default-features = false }
+once_cell = { version = "1.19.0", default-features = false, features = ["std", "critical-section"] }

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+lint:  ## cargo check and clippy. Skip clippy on guest code since it's not supported by risc0
+	cargo +nightly fmt --all --check
+	cargo check --all-targets --all-features
+	cargo clippy --all-targets --all-features
+
+test:
+	cargo test  --all-features --all-targets
+
+check-features: ## Checks that project compiles with all combinations of features.
+	cargo hack check --workspace --feature-powerset --all-targets

--- a/crates/sov-cycle-macros/Cargo.toml
+++ b/crates/sov-cycle-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sov-cycle-macros"
-description = "Macros to wrap functions and emit cycle counts from the risc0 VM"
+description = "Macros to wrap functions and emit cycle counts from the ZK VM"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }

--- a/crates/sov-cycle-macros/src/lib.rs
+++ b/crates/sov-cycle-macros/src/lib.rs
@@ -60,11 +60,13 @@ where
 fn cycles_risc0(ident: &Ident, block: &Block) -> Box<Block> {
     parse_quote! {
         {
-            let before = ::sov_cycle_utils::risc0::get_cycle_count();
+            let cycles_before = ::sov_cycle_utils::risc0::get_cycle_count();
             let result = (|| #block)();
-            let after = ::sov_cycle_utils::risc0::get_cycle_count();
+            let cycles_after = ::sov_cycle_utils::risc0::get_cycle_count();
+            let heap_bytes_free_after = ::sov_cycle_utils::risc0::get_available_heap();
 
-            ::sov_cycle_utils::risc0::report_cycle_count(stringify!(#ident), after - before);
+            let cycles = cycles_after.saturating_sub(cycles_before);
+            ::sov_cycle_utils::risc0::report_cycle_count(stringify!(#ident), cycles, heap_bytes_free_after);
             result
         }
     }
@@ -76,8 +78,9 @@ fn cycles_sp1(ident: &Ident, block: &Block) -> Box<Block> {
             let before = ::sov_cycle_utils::sp1::get_cycle_count();
             let result = (move || #block)();
             let after = ::sov_cycle_utils::sp1::get_cycle_count();
+            let heap_bytes_free_after = ::sov_cycle_utils::sp1::get_available_heap();
 
-            ::sov_cycle_utils::sp1::report_cycle_count(stringify!(#ident), after - before);
+            ::sov_cycle_utils::sp1::report_cycle_count(stringify!(#ident), after - before, heap_bytes_free_after);
             result
         }
     })

--- a/crates/sov-cycle-macros/src/lib.rs
+++ b/crates/sov-cycle-macros/src/lib.rs
@@ -23,7 +23,7 @@ use syn::{parse2, parse_quote, Block, Ident, ItemFn};
 pub fn cycle_tracker(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = TokenStream2::from(item);
     wrap_function_with(cycles, input)
-        .unwrap_or_else(|err| err.to_compile_error().into())
+        .unwrap_or_else(|err| err.to_compile_error())
         .into()
 }
 
@@ -54,7 +54,7 @@ where
     } = &input;
     input.block = f(ident, block);
 
-    Ok(input.into_token_stream().into())
+    Ok(input.into_token_stream())
 }
 
 fn cycles_risc0(ident: &Ident, block: &Block) -> Box<Block> {

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sov-cycle-utils"
 authors = { workspace = true }
-description = "Utilities for counting risc0 VM cycles consumed by functions"
+description = "Utilities for counting ZK VM cycles consumed by functions"
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
@@ -13,19 +13,22 @@ resolver = "2"
 autotests = false
 
 [dependencies]
+anyhow = { version = "1.0", default-features = false, optional = true }
 sp1-lib = { workspace = true, default-features = false, optional = true }
 risc0-zkvm = { workspace = true, default-features = false, features = [
-	"std",
+    "std",
 ], optional = true }
 risc0-zkvm-platform = { workspace = true, optional = true }
 sov-cycle-macros = { path = "../sov-cycle-macros", optional = true }
 once_cell = { workspace = true, features = [
     "alloc",
-]  }
+] }
 
 [features]
 default = ["macros"]
 macros = ["dep:sov-cycle-macros"]
 risc0 = ["dep:risc0-zkvm", "dep:risc0-zkvm-platform"]
 sp1 = ["dep:sp1-lib"]
-native = []
+native = [
+    "dep:anyhow"
+]

--- a/crates/utils/README.md
+++ b/crates/utils/README.md
@@ -1,0 +1,5 @@
+# Description
+
+Utilities for tracking cycle counts and memory usage in ZK VMs
+
+Supports risc0 and SP1

--- a/crates/utils/src/lib.rs
+++ b/crates/utils/src/lib.rs
@@ -5,6 +5,7 @@ pub mod sp1;
 
 #[cfg(feature = "native")]
 pub use native::{increment_metric, METRICS_HASHMAP};
+
 #[cfg(feature = "native")]
 mod native {
     use once_cell::sync::Lazy;

--- a/crates/utils/src/risc0.rs
+++ b/crates/utils/src/risc0.rs
@@ -3,7 +3,6 @@ pub use actual_impl::*;
 
 #[cfg(feature = "risc0")]
 mod actual_impl {
-    use super::*;
     #[cfg(feature = "native")]
     use anyhow::Context;
     use risc0_zkvm;

--- a/crates/utils/src/risc0.rs
+++ b/crates/utils/src/risc0.rs
@@ -3,9 +3,45 @@ pub use actual_impl::*;
 
 #[cfg(feature = "risc0")]
 mod actual_impl {
+    use super::*;
+    #[cfg(feature = "native")]
+    use anyhow::Context;
     use risc0_zkvm;
     use risc0_zkvm_platform::syscall::sys_cycle_count;
     use risc0_zkvm_platform::syscall::SyscallName;
+    use std::hint::black_box;
+
+    #[cfg(feature = "native")]
+    pub fn deserialize_metrics_call(serialized: &[u8]) -> anyhow::Result<(String, u64, u64)> {
+        let null_pos = serialized
+            .iter()
+            .position(|&b| b == 0)
+            .context("Could not find separator in provided bytes")?;
+
+        let (name_bytes, metric_bytes_with_null) = serialized.split_at(null_pos);
+        let name = std::str::from_utf8(name_bytes)
+            .context("Invalid UTF-8 in name")?
+            .to_owned();
+
+        let cycles_bytes = &metric_bytes_with_null[1..9]; // Skip the null terminator
+        let cycles = u64::from_le_bytes(cycles_bytes.try_into()?); // Convert bytes back into usize
+                                                                   // Upper bound so we don't panice if more things
+        let free_heap_bytes = &metric_bytes_with_null[9..17];
+        let free_heap = u64::from_le_bytes(free_heap_bytes.try_into()?);
+        Ok((name, cycles, free_heap))
+    }
+
+    fn serialize_metric(name: &str, cycle_count: u64, free_heap_bytes: u64) -> Vec<u8> {
+        let name_bytes = name.as_bytes();
+        // We know the exact capacity:
+        // name_bytes plus one null terminator plus two u64s (16 bytes total)
+        let mut serialized = Vec::with_capacity(name_bytes.len() + 1 + 16);
+        serialized.extend_from_slice(name_bytes);
+        serialized.push(0);
+        serialized.extend_from_slice(&cycle_count.to_le_bytes());
+        serialized.extend_from_slice(&free_heap_bytes.to_le_bytes());
+        serialized
+    }
 
     // Safety: string is null terminated
     pub const SYSCALL_NAME_METRICS: SyscallName =
@@ -19,18 +55,48 @@ mod actual_impl {
         sys_cycle_count()
     }
 
-    pub fn report_cycle_count(name: &str, count: u64) {
-        // simple serialization to avoid pulling in bincode or other libs
-        let mut serialized = Vec::new();
-        serialized.extend(name.as_bytes());
-        serialized.push(0);
-        let size_bytes = count.to_le_bytes();
-        serialized.extend(&size_bytes);
+    pub fn report_cycle_count(name: &str, cycle_count: u64, free_heap_bytes: u64) {
+        let serialized = serialize_metric(name, cycle_count, free_heap_bytes);
+        risc0_zkvm::guest::env::send_recv_slice::<u8, u8>(SYSCALL_NAME_METRICS, &serialized);
+    }
 
-        // calculate the syscall name.
-        let metrics_syscall_name = SYSCALL_NAME_METRICS;
+    /// Returns how many bytes of heap are still available
+    pub fn get_available_heap() -> u64 {
+        // TODO hack, this is allocating just to get a pointer to the top of the heap.
+        // Assumes bump alloc
+        // When embed alloc is fixed https://github.com/risc0/risc0/pull/2677 can use that.
+        let new_alloc = black_box(Box::new(()));
+        let available = 0x0C00_0000 - &new_alloc as *const _ as usize;
+        available as u64
+    }
 
-        risc0_zkvm::guest::env::send_recv_slice::<u8, u8>(metrics_syscall_name, &serialized);
+    #[cfg(all(test, feature = "native"))]
+    mod tests {
+        use super::*;
+
+        fn check_in_out(name: &str, cycle_count: u64, free_heap_bytes: u64) {
+            let serialized = serialize_metric(name, cycle_count, free_heap_bytes);
+
+            let (de_name, de_cycles, de_heap) = deserialize_metrics_call(&serialized[..]).unwrap();
+
+            assert_eq!(de_name, name, "wrong metric name");
+            assert_eq!(de_cycles, cycle_count, "wrong cycle count");
+            assert_eq!(de_heap, free_heap_bytes, "wrong free heap");
+        }
+
+        #[test]
+        fn callback_serialize_and_deserialize() {
+            let cases = vec![
+                ("zeros", 0, 0),
+                ("something", 1024, 4095),
+                ("different", 9056, 3870),
+                ("one_max", u64::MAX, 514),
+                ("two_max", 512, u64::MAX),
+            ];
+            for (name, cycles, heap_bytes) in cases {
+                check_in_out(name, cycles, heap_bytes);
+            }
+        }
     }
 }
 
@@ -42,7 +108,11 @@ mod facade {
         0
     }
 
-    pub fn report_cycle_count(_name: &str, _count: u64) {
+    pub fn report_cycle_count(_name: &str, _count: u64, _free_heap_bytes: u64) {
         panic!("Reporting risc0 cycle count without risc0 feature enabled");
+    }
+
+    pub fn get_available_heap() -> u64 {
+        0x0C00_0000
     }
 }

--- a/crates/utils/src/sp1.rs
+++ b/crates/utils/src/sp1.rs
@@ -10,7 +10,7 @@ mod actual_impl {
     pub const FD_METRICS_HOOK: u32 = 1001;
 
     /// Report the cycle count to the host, if available. Otherwise, this is a no-op.
-    pub fn report_cycle_count(name: &str, count: u64) {
+    pub fn report_cycle_count(name: &str, count: u64, _free_heap_bytes: u64) {
         // Cheap serialization: concat the u64 (fixed size) with the string (unknown size).
         let mut buf = Vec::from(count.to_le_bytes());
         buf.extend_from_slice(name.as_bytes());
@@ -27,6 +27,11 @@ mod actual_impl {
                 .expect("Failed to read cycle count before hook."),
         )
     }
+
+    /// Returns how many bytes of heap are still available
+    pub fn get_available_heap() -> u64 {
+        0x0C00_0000
+    }
 }
 
 #[cfg(not(feature = "sp1"))]
@@ -40,7 +45,11 @@ mod facade {
     }
 
     /// Report the cycle count to the host.
-    pub fn report_cycle_count(_name: &str, _count: u64) {
+    pub fn report_cycle_count(_name: &str, _count: u64, _free_heap_bytes: u64) {
         panic!("Reporting sp1 cycle count without sp1 feature enabled");
+    }
+
+    pub fn get_available_heap() -> u64 {
+        0x0C00_0000
     }
 }


### PR DESCRIPTION
Adds reporting of free heap bytes from metrics syscall.

Also provides helper for deserializing passed data, so caller doesn't have to do it manually.